### PR TITLE
Add logic to top menu for disabling main page clicks when open

### DIFF
--- a/app/assets/javascripts/shanti_integration/shanti-main.js
+++ b/app/assets/javascripts/shanti_integration/shanti-main.js
@@ -197,6 +197,8 @@
           event.stopPropagation();
           $('#menu').slideToggle(200);
           $('.menu-toggle').toggleClass('show-topmenu');
+          $('.main-wrapper').toggleClass('disabled-by-top-menu-open');
+          $('#tree').toggleClass('disabled-by-top-menu-open');
           $('.collections').slideUp(200);
           $('.menu-exploretoggle').removeClass('show-topmenu');
        });
@@ -209,6 +211,8 @@
 
       $(document).click( function(){
           $('.menu-toggle').removeClass('show-topmenu');
+          $('.main-wrapper').removeClass('disabled-by-top-menu-open');
+          $('#tree').removeClass('disabled-by-top-menu-open');
           $('#menu').hide(100);
       });
 

--- a/app/assets/stylesheets/shanti_integration/shanti_sarvaka_theme.css.scss
+++ b/app/assets/stylesheets/shanti_integration/shanti_sarvaka_theme.css.scss
@@ -17,6 +17,11 @@
  *= require_self
  */
 
+/* fix for top menu to not propagete clicks to elements on the main wrapper */
+.disabled-by-top-menu-open {
+  pointer-events:none;
+}
+/* END - fix for top menu to not propagete clicks to elements on the main wrapper */
  /* shanti_sarvaka_theme/search  adds fixes to advance search only on Rails*/
 .ui-resizable-handle {
   font-size: inherit;


### PR DESCRIPTION
There is a bug when clicking on the menu and the menu is over any other
item that has a click action, the click is propagating to them. Build
the logic to add a class disabled-by-top-menu-open to specif items that
were causing problem. This only prevents the clicks going through when
the first level of the menu is open, the event clicks should stop
propagation on their own code, this was done on kmaps_engine for the
public view list partial.