### PR TITLE
Fixes dropdown scrolling on bottom of browser view area - MANU-6498

### DIFF
--- a/lib/shanti_integration/version.rb
+++ b/lib/shanti_integration/version.rb
@@ -1,3 +1,3 @@
 module ShantiIntegration
-  VERSION = '3.5.0'
+  VERSION = '3.5.1'
 end

--- a/vendor/assets/stylesheets/shanti_sarvaka_theme/shanti-main.css.scss
+++ b/vendor/assets/stylesheets/shanti_sarvaka_theme/shanti-main.css.scss
@@ -3737,6 +3737,7 @@ div#carousel-buttons {
   border-radius: 0.8rem;
   background-clip: padding-box;
   margin-top: 0.2rem;
+  overflow: scroll !important;
 }
 
 .bootstrap-select.btn-group .dropdown-menu.inner{


### PR DESCRIPTION
**Jira Issue:** MANU-6498

**Changes proposed in this pull request:**

 + Fix dropdown scrolling to allow access to all items

**Details of the implementation:**

When a dropdown is located at the end of the browser view area, the user
can't access all teh elements of the dropdown.

We need to find a compelte solution, this is just a hotfix. The hotfix
causes an additional scroll bar in some cases.
